### PR TITLE
Di 1678 transfer workbooks to clingen

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ docker exec ${container_id} sh -c 'python3 /app/sc_wgs_monitoring/main.py -s -t 
 # start workbook jobs from dnanexus files
 docker exec ${container_id} sh -c 'python3 /app/sc_wgs_monitoring/main.py -s -ids ${file_id} ${file_id} ${file_id}'
 # start workbook jobs from local files
-docker exec ${container_id} sh -c 'python3 /app/sc_wgs_monitoring/main.py -s -ids ${file} ${file} ${file}'
+docker exec ${container_id} sh -c 'python3 /app/sc_wgs_monitoring/main.py -s -l ${file} ${file} ${file}'
 
 # check for jobs finished in the last hour
-docker exec ${container_id} sh -c 'python3 /app/sc_wgs_monitoring/main.py -c -t 5m'
+docker exec ${container_id} sh -c 'python3 /app/sc_wgs_monitoring/main.py -c -t 1h'
 # upload files from the specified jobs
 docker exec ${container_id} sh -c 'python3 /app/sc_wgs_monitoring/main.py -c -ids ${job_id}'
 ```

--- a/main.py
+++ b/main.py
@@ -455,6 +455,14 @@ if __name__ == "__main__":
         help="Project ID in which to upload and process the workbooks",
     )
     config_override.add_argument(
+        "-pid_div_id",
+        "--pid_div_id",
+        help=(
+            "The ID of the div element that contains the PID information in "
+            "the supplementary HTML"
+        ),
+    )
+    config_override.add_argument(
         "-app_id",
         "--sd_wgs_workbook_app_id",
         help="SD WGS workbook app ID",

--- a/main.py
+++ b/main.py
@@ -293,8 +293,9 @@ def main(**args):
             # check the job statuses, update the db and download the files in
             # the appropriate locations
             for sample, data in dnanexus_data.items():
+                job = data["job"]
                 # get job status
-                job_status = data["job"].state
+                job_status = job.state
 
                 db.update_in_db(
                     session, sc_wgs_table, sample, {"job_status": job_status}

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import multiprocessing
 from pathlib import Path
 import re
 
@@ -40,6 +41,9 @@ def main(**args):
     dnanexus.login_to_dnanexus(args["dnanexus_token"])
     sd_wgs_project = dxpy.bindings.DXProject(config_data["project_id"])
     dxpy.set_workspace_id(sd_wgs_project.id)
+    sc_wgs_workbook_app = dxpy.bindings.dxapp.DXApp(
+        dxid=config_data["sd_wgs_workbook_app_id"]
+    )
 
     date = datetime.date.today().strftime("%y%m%d")
 
@@ -58,20 +62,20 @@ def main(**args):
             r"\..*\.supplementary\.html": "supplementary_html",
         }
 
-        # handle given dnanexus file ids
-        if args["dnanexus_file_ids"]:
+        # handle given dnanexus ids
+        if args["dnanexus_ids"]:
             if all(
                 [
                     check.check_dnanexus_id(file)
-                    for file in args["dnanexus_file_ids"]
+                    for file in args["dnanexus_ids"]
                 ]
             ):
                 new_files = [
-                    dxpy.DXFile(file) for file in args["dnanexus_file_ids"]
+                    dxpy.DXFile(file) for file in args["dnanexus_ids"]
                 ]
             else:
                 raise AssertionError(
-                    f"Provided files {args['dnanexus_file_ids']} are not all "
+                    f"Provided files {args['dnanexus_ids']} are not all "
                     "DNAnexus file ids"
                 )
 
@@ -116,11 +120,13 @@ def main(**args):
                     )
                     exit()
 
+            # find the html file and remove the pid div from it
             supplementary_html = [
                 file
                 for file in new_files
                 if re.search(r".*\.supplementary\.html", file.name)
             ][0]
+
             new_html = utils.remove_pid_div_from_supplementary_file(
                 supplementary_html, config_data["pid_div_id"]
             )
@@ -128,6 +134,7 @@ def main(**args):
             with open(supplementary_html, "w") as file:
                 file.write(str(new_html))
 
+        # check if the files have expected suffixes
         if not all(
             check.check_file_input_name_is_correct(file.name, patterns)
             for file in new_files
@@ -195,15 +202,10 @@ def main(**args):
                 )
                 print("Uploaded the files to DNAnexus")
 
-            # starting the jobs
-            for sample_id, data in dnanexus_data.items():
-                # setup dict with the columns that need to be populated
-                sample_data = {
-                    column.name: None
-                    for column in sc_wgs_table.columns
-                    if column.name != "id"
-                }
+            args_for_starting_jobs = []
 
+            # organise data for preparation for starting the jobs
+            for sample_id, data in dnanexus_data.items():
                 inputs = {}
 
                 for file in data["files"]:
@@ -213,21 +215,50 @@ def main(**args):
                         )
                     )
 
-                all_inputs = inputs | {
-                    ref_input_name: {
-                        "$dnanexus_link": config_data["workbook_inputs"][
-                            ref_input_name
-                        ]
-                    }
-                    for ref_input_name in config_data["workbook_inputs"]
-                }
-
-                job = dnanexus.start_wgs_workbook_job(
-                    all_inputs,
-                    config_data["sd_wgs_workbook_app_id"],
+                args_for_starting_jobs.append(
+                    (
+                        inputs
+                        | {
+                            ref_input_name: {
+                                "$dnanexus_link": config_data[
+                                    "workbook_inputs"
+                                ][ref_input_name]
+                            }
+                            for ref_input_name in config_data[
+                                "workbook_inputs"
+                            ]
+                        }
+                    ),
+                    sc_wgs_workbook_app,
+                    f"{sample_id} | {sc_wgs_workbook_app.name}"
                     f"{data['folder']}/output",
                 )
-                # job_id.wait_on_done(10)
+
+            # start the jobs
+            with multiprocessing.Pool(processes=10) as pool:
+                job_ids = pool.starmap(
+                    dnanexus.start_wgs_workbook_job, args_for_starting_jobs
+                )
+
+            print("Jobs started")
+
+            jobs = []
+
+            for job_id in job_ids:
+                job = dxpy.DXJob(job_id)
+                jobs.append(job)
+
+                sample_id = job.name.split(" | ")[0]
+
+                if sample_id in dnanexus_data:
+                    dnanexus[sample_id]["job"] = job
+
+                # setup dict with the columns that need to be populated
+                sample_data = {
+                    column.name: None
+                    for column in sc_wgs_table.columns
+                    if column.name != "id"
+                }
 
                 # populate the dict
                 sample_data["referral_id"] = sample_id
@@ -244,7 +275,14 @@ def main(**args):
 
             db.insert_in_db(session, sc_wgs_table, db_data)
 
-            print("Job started + successful db update")
+            print("Successful db update")
+
+            for job in jobs:
+                job.wait_on_done(10)
+
+            # TODO update database with the job status
+            # TODO download files in the upload location
+            # TODO update database with clingen location?
 
         else:
             # TODO probably send a slack log message
@@ -252,17 +290,24 @@ def main(**args):
 
     # check jobs that have finished
     if args["check_jobs"]:
-        executions = dxpy.bindings.find_executions(
-            executable=config_data["sd_wgs_workbook_app_id"],
-            project=sd_wgs_project,
-            created_after=args["time_to_check"],
-            describe=True,
-        )
+        if args["dnanexus_ids"]:
+            executions = [
+                dxpy.DXJob(dxid=job_id).describe()
+                for job_id in args["dnanexus_ids"]
+            ]
+        else:
+            executions = dxpy.bindings.find_executions(
+                executable=config_data["sd_wgs_workbook_app_id"],
+                project=sd_wgs_project,
+                created_after=f"-{args['time_to_check']}",
+            )
 
         for execution in executions:
-            for job_output in dnanexus.get_output_id(execution):
+            job = dxpy.DXJob(execution["id"])
+
+            for job_output in dnanexus.get_output_id(job.describe()):
                 dxpy.bindings.dxfile_functions.download_dxfile(
-                    job_output, config_data["clingen_location"]
+                    job_output, config_data["clingen_upload_location"]
                 )
 
 
@@ -283,9 +328,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-ids",
-        "--dnanexus_file_ids",
+        "--dnanexus_ids",
         nargs="+",
-        help="DNAnexus ids for the input of the workbook job",
+        help=(
+            "DNAnexus ids either for providing inputs for the workbook jobs "
+            "or job ids for checking jobs"
+        ),
     )
     parser.add_argument(
         "-t",
@@ -301,10 +349,18 @@ if __name__ == "__main__":
 
     type_processing = parser.add_mutually_exclusive_group()
     type_processing.add_argument(
-        "-s", "--start_jobs", action="store_true", default=False
+        "-s",
+        "--start_jobs",
+        action="store_true",
+        default=False,
+        help="Flag argument required for starting jobs",
     )
     type_processing.add_argument(
-        "-c", "--check_jobs", action="store_true", default=False
+        "-c",
+        "--check_jobs",
+        action="store_true",
+        default=False,
+        help="Flag argument required for checking jobs",
     )
 
     subparser = parser.add_subparsers(help="")

--- a/sc_wgs_monitoring/db.py
+++ b/sc_wgs_monitoring/db.py
@@ -1,6 +1,6 @@
 from typing import Tuple, List
 
-from sqlalchemy import create_engine, select, insert
+from sqlalchemy import create_engine, select, insert, update
 from sqlalchemy.schema import Table
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.sql.schema import MetaData
@@ -84,4 +84,30 @@ def insert_in_db(session: Session, table: Table, data: List):
 
     insert_obj = insert(table).values(data)
     session.execute(insert_obj)
+    session.commit()
+
+
+def update_in_db(
+    session: Session, table: Table, referral_id: str, update_data: dict
+):
+    """Update the database where the referral id is equal to the one given
+    with the given update data
+
+    Parameters
+    ----------
+    session : Session
+        Session SQLAlchemy object
+    table : Table
+        Table SQLAlchemy object
+    referral_id : str
+        Referral id to get the appropriate row
+    update_data : dict
+        Dict containing the data used for updating the row
+    """
+    update_obj = (
+        update(table)
+        .where(table.c.referral_id == referral_id)
+        .values(**update_data)
+    )
+    session.execute(update_obj)
     session.commit()

--- a/sc_wgs_monitoring/dnanexus.py
+++ b/sc_wgs_monitoring/dnanexus.py
@@ -85,6 +85,8 @@ def get_output_id(execution: Dict) -> str:
         if len(job_output) == 1:
             return job_output
 
+    raise AssertionError(f"{execution['id']} is probably not done.")
+
 
 def assign_dxfile_to_workbook_input(file: dxpy.DXFile, patterns: dict) -> dict:
     """Assign DXFile to a workbook job input name
@@ -117,7 +119,10 @@ def assign_dxfile_to_workbook_input(file: dxpy.DXFile, patterns: dict) -> dict:
 
 
 def start_wgs_workbook_job(
-    workbook_inputs: Dict, app_id: str, output_folder: str
+    workbook_inputs: Dict,
+    app: dxpy.DXApp,
+    job_name: str,
+    output_folder: str,
 ) -> dxpy.DXJob:
     """Start the WHS Solid cancer workbook job
 
@@ -136,7 +141,4 @@ def start_wgs_workbook_job(
         DXJob object
     """
 
-    return dxpy.bindings.dxapp.DXApp(dxid=app_id).run(
-        workbook_inputs,
-        folder=output_folder,
-    )
+    return app.run(workbook_inputs, name=job_name, folder=output_folder)

--- a/sc_wgs_monitoring/dnanexus.py
+++ b/sc_wgs_monitoring/dnanexus.py
@@ -85,6 +85,8 @@ def get_output_id(execution: Dict) -> str:
         if len(job_output) == 1:
             return job_output
 
+    raise AssertionError(f"{execution['id']} is probably not done.")
+
 
 def assign_dxfile_to_workbook_input(file: dxpy.DXFile, patterns: dict) -> dict:
     """Assign DXFile to a workbook job input name
@@ -117,7 +119,10 @@ def assign_dxfile_to_workbook_input(file: dxpy.DXFile, patterns: dict) -> dict:
 
 
 def start_wgs_workbook_job(
-    workbook_inputs: Dict, app_id: str, output_folder: str
+    workbook_inputs: Dict,
+    app: dxpy.DXApp,
+    job_name: str,
+    output_folder: str,
 ) -> dxpy.DXJob:
     """Start the WGS Solid cancer workbook job
 
@@ -136,7 +141,4 @@ def start_wgs_workbook_job(
         DXJob object
     """
 
-    return dxpy.bindings.dxapp.DXApp(dxid=app_id).run(
-        workbook_inputs,
-        folder=output_folder,
-    )
+    return app.run(workbook_inputs, name=job_name, folder=output_folder)

--- a/sc_wgs_monitoring/dnanexus.py
+++ b/sc_wgs_monitoring/dnanexus.py
@@ -127,6 +127,8 @@ def start_wgs_workbook_job(
         Dict containing the inputs for the sample
     app_id : str
         DNAnexus app to use for running the job
+    output_folder : str
+        Output folder in DNAnexus for the job
 
     Returns
     -------

--- a/sc_wgs_monitoring/dnanexus.py
+++ b/sc_wgs_monitoring/dnanexus.py
@@ -23,7 +23,7 @@ def login_to_dnanexus(token: str):
 
 def upload_input_files(
     date: str, project: dxpy.DXProject, sample_files: Dict
-) -> list:
+) -> dict:
     """Upload the input files required for creating the WGS workbook
 
     Parameters
@@ -37,8 +37,8 @@ def upload_input_files(
 
     Returns
     -------
-    list
-        List of folders where the inputs were moved to
+    dict
+        Dict of samples and their files in dnanexus and their location
     """
 
     data = {}

--- a/sc_wgs_monitoring/dnanexus.py
+++ b/sc_wgs_monitoring/dnanexus.py
@@ -75,17 +75,8 @@ def get_output_id(execution: Dict) -> str:
         File id of the WGS workbook job output
     """
 
-    if execution["describe"]["state"] == "done":
-        job_output = [
-            output_id
-            for output_id in execution["output"]["published_files"].values()
-        ]
-
-        # sense check we have one output only
-        if len(job_output) == 1:
-            return job_output
-
-    raise AssertionError(f"{execution['id']} is probably not done.")
+    job_output = execution["output"]["workbook"]["$dnanexus_link"]
+    return job_output
 
 
 def assign_dxfile_to_workbook_input(file: dxpy.DXFile, patterns: dict) -> dict:

--- a/sc_wgs_monitoring/dnanexus.py
+++ b/sc_wgs_monitoring/dnanexus.py
@@ -121,8 +121,10 @@ def start_wgs_workbook_job(
     ----------
     workbook_inputs : Dict
         Dict containing the inputs for the sample
-    app_id : str
+    app : dxpy.DXApp
         DNAnexus app to use for running the job
+    job_name : str
+        String with the job name to give to the job
     output_folder : str
         Output folder in DNAnexus for the job
 


### PR DESCRIPTION
- generalise the use of dnanexus ids i.e. use for giving file ids and job ids
- print the sample ids detected and the associated files
- simplify building the inputs
- multiprocessing for starting dnanexus jobs
- wait for jobs to be done before updating the statuses in the database
- whole new section for checking workbook jobs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/sc_wgs_monitoring/6)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced parallel processing to start multiple DNAnexus WGS workbook jobs concurrently, improving job submission speed.
  - Enhanced job status tracking and clearer reporting of detected samples and files.
  - Improved database updates with more detailed job metadata and output file locations.

- **Improvements**
  - Renamed command-line argument for DNAnexus IDs for clearer usage.
  - Added and reorganised command-line arguments with improved help messages.
  - Refined job submission and output file handling for better reliability and clarity.
  - Expanded and clarified documentation with detailed command-line usage examples and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->