### PR TITLE
Di 2413 flexibility in the instance type used

### DIFF
--- a/main.py
+++ b/main.py
@@ -420,6 +420,7 @@ def main(**args):
                         patterns,
                         config_data["workbook_inputs"],
                         sc_wgs_workbook_app,
+                        config_data["instance_type"],
                     )
                 )
 
@@ -738,6 +739,11 @@ if __name__ == "__main__":
             "Clingen location to download data to (used to override config "
             "data)"
         ),
+    )
+    config_override.add_argument(
+        "-instance_type",
+        "--instance_type",
+        help="Instance type to use for the jobs",
     )
 
     args = vars(parser.parse_args())

--- a/sc_wgs_monitoring/dnanexus.py
+++ b/sc_wgs_monitoring/dnanexus.py
@@ -131,7 +131,8 @@ def prepare_inputs(
     patterns: list,
     workbook_inputs: dict,
     workbook_app: dxpy.DXApp,
-) -> dict:
+    instance_type: str,
+) -> tuple:
     """Prepare the inputs for starting the jobs
 
     Parameters
@@ -151,8 +152,8 @@ def prepare_inputs(
 
     Returns
     -------
-    dict
-        Dict containing all the input names and their inputs
+    tuple
+        Tuple containing all the input names and their inputs
     """
 
     inputs = {}
@@ -169,6 +170,7 @@ def prepare_inputs(
         workbook_app,
         sample,
         f"{folder}/output",
+        instance_type,
     )
 
 
@@ -177,6 +179,7 @@ def start_wgs_workbook_job(
     app: dxpy.DXApp,
     job_name: str,
     output_folder: str,
+    instance_type: str,
 ) -> dxpy.DXJob:
     """Start the WGS Solid cancer workbook job
 
@@ -197,4 +200,9 @@ def start_wgs_workbook_job(
         DXJob object
     """
 
-    return app.run(workbook_inputs, name=job_name, folder=output_folder)
+    return app.run(
+        workbook_inputs,
+        name=job_name,
+        folder=output_folder,
+        instance_type=instance_type,
+    )

--- a/sc_wgs_monitoring/utils.py
+++ b/sc_wgs_monitoring/utils.py
@@ -394,12 +394,14 @@ def start_parallel_workbook_jobs(
                 app,
                 job_name,
                 output_folder,
+                instance_type,
             ): job_name
             for (
                 inputs,
                 app,
                 job_name,
                 output_folder,
+                instance_type,
             ) in args_for_starting_jobs
         }
 


### PR DESCRIPTION
- Allow user to give instance type when starting the script
- Handle instance type in the config file
- Fixes #20 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/sc_wgs_monitoring/23)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support to specify the DNAnexus instance type for workbook jobs.
  * New CLI/config option: -instance_type / --instance_type (“Instance type to use for the jobs”).
  * Applies to both single and parallel job submissions so users can tailor performance and cost.
  * Backwards compatible: if not set, existing default behaviour is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->